### PR TITLE
feat: add showPinout to AssemblyViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ export default () => (
 )
 ```
 
+Render the same circuit as a pinout by enabling `showPinout`:
+
+```tsx
+<AssemblyViewer circuitJson={circuitJson} showPinout />
+```
+
 ## References
 
 - This repo is heavily based on the [schematic-viewer](https://github.com/tscircuit/schematic-viewer) repo, if you're trying to add functionality you may

--- a/lib/components/AssemblyViewer.tsx
+++ b/lib/components/AssemblyViewer.tsx
@@ -1,14 +1,17 @@
-import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
-import { convertCircuitJsonToAssemblySvg } from "circuit-to-svg"
-import { useMemo, useRef, useState } from "react"
-import { useResizeHandling } from "../hooks/use-resize-handling"
+import type { CircuitJson } from "circuit-json"
 import {
-  identity,
+  convertCircuitJsonToAssemblySvg,
+  convertCircuitJsonToPinoutSvg,
+} from "circuit-to-svg"
+import { enableDebug } from "lib/utils/debug"
+import { useMemo, useRef, useState } from "react"
+import {
   fromString,
+  identity,
   toString as transformToString,
 } from "transformation-matrix"
-import type { CircuitJson } from "circuit-json"
-import { enableDebug } from "lib/utils/debug"
+import { useMouseMatrixTransform } from "use-mouse-matrix-transform"
+import { useResizeHandling } from "../hooks/use-resize-handling"
 
 interface Props {
   circuitJson: any[]
@@ -17,6 +20,7 @@ interface Props {
   debugGrid?: boolean
   editingEnabled?: boolean
   debug?: boolean
+  showPinout?: boolean
 }
 
 export const AssemblyViewer = ({
@@ -24,6 +28,7 @@ export const AssemblyViewer = ({
   containerStyle,
   debugGrid = false,
   debug = false,
+  showPinout = false,
 }: Props) => {
   if (debug) {
     enableDebug()
@@ -45,11 +50,15 @@ export const AssemblyViewer = ({
   const svgString = useMemo(() => {
     if (!containerWidth || !containerHeight) return ""
 
-    return convertCircuitJsonToAssemblySvg(circuitJson as any, {
+    const convertCircuitJsonToSvg = showPinout
+      ? convertCircuitJsonToPinoutSvg
+      : convertCircuitJsonToAssemblySvg
+
+    return convertCircuitJsonToSvg(circuitJson as any, {
       width: containerWidth,
       height: containerHeight || 720,
     })
-  }, [circuitJson, containerWidth, containerHeight])
+  }, [circuitJson, containerWidth, containerHeight, showPinout])
 
   const realToSvgProjection = useMemo(() => {
     if (!svgString) return identity()


### PR DESCRIPTION
Fixes #7

## Summary
- Add a `showPinout` prop to `AssemblyViewer`.
- Reuse the existing pinout SVG converter when the prop is enabled.
- Document the new prop in the README.

## Verification
- `bun run build`
- `bun x tsc --noEmit`
- `bun x biome check lib\components\AssemblyViewer.tsx README.md`
- `git diff --check`